### PR TITLE
WIP: Add `forall a. Show (t a)` superclass to `GShow` -- contains #20

### DIFF
--- a/src/Data/GADT/Internal.hs
+++ b/src/Data/GADT/Internal.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP                 #-}
+#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE DefaultSignatures   #-}
+#endif
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
@@ -157,10 +159,12 @@ class GEq f where
     --
     -- (Making use of the 'DSum' type from <https://hackage.haskell.org/package/dependent-sum/docs/Data-Dependent-Sum.html Data.Dependent.Sum> in both examples)
     geq :: f a -> f b -> Maybe (a :~: b)
+#if __GLASGOW_HASKELL__ >= 702
     default geq :: GCompare f => f a -> f b -> Maybe (a :~: b)
     geq a b = case gcompare a b of
         GEQ -> Just Refl
         _   -> Nothing
+#endif
 
 
 -- |If 'f' has a 'GEq' instance, this function makes a suitable default

--- a/src/Data/GADT/Internal.hs
+++ b/src/Data/GADT/Internal.hs
@@ -48,6 +48,10 @@ import qualified Type.Reflection    as TR
 -- > instance GShow t where gshowsPrec = showsPrec
 class GShow t where
     gshowsPrec :: Int -> t a -> ShowS
+#if __GLASGOW_HASKELL__ >= 702
+    default gshowsPrec :: Show (t a) => Int -> t a -> ShowS
+    gshowsPrec = showsPrec
+#endif
 
 gshows :: GShow t => t a -> ShowS
 gshows = gshowsPrec (-1)

--- a/src/Data/GADT/Internal.hs
+++ b/src/Data/GADT/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
@@ -156,6 +157,11 @@ class GEq f where
     --
     -- (Making use of the 'DSum' type from <https://hackage.haskell.org/package/dependent-sum/docs/Data-Dependent-Sum.html Data.Dependent.Sum> in both examples)
     geq :: f a -> f b -> Maybe (a :~: b)
+    default geq :: GCompare f => f a -> f b -> Maybe (a :~: b)
+    geq a b = case gcompare a b of
+      GEQ -> Just Refl
+      _ -> Nothing
+
 
 -- |If 'f' has a 'GEq' instance, this function makes a suitable default
 -- implementation of '(==)'.

--- a/src/Data/GADT/Internal.hs
+++ b/src/Data/GADT/Internal.hs
@@ -159,8 +159,8 @@ class GEq f where
     geq :: f a -> f b -> Maybe (a :~: b)
     default geq :: GCompare f => f a -> f b -> Maybe (a :~: b)
     geq a b = case gcompare a b of
-      GEQ -> Just Refl
-      _ -> Nothing
+        GEQ -> Just Refl
+        _   -> Nothing
 
 
 -- |If 'f' has a 'GEq' instance, this function makes a suitable default


### PR DESCRIPTION
As `GShow` is isomorphic to this constraint, it's nice to add this super
class. This reminds people that if they implement `GShow` they should
also implement `forall a. Show (t a)`, as its both incredibly easy to do
so and never (in practice) an additional dependency.

Unforunately, this change doesn't yet type-check because the instances
in base for `Sum` and `Product` are overly conservative: they assume
there is a field with a type related to the GADT index. That should be
fixed, and this PR can be pointed to as an example of why the problem
isn't just theoretical.

