### PR TITLE
Add newtypes for Monoid instances

### DIFF
--- a/src/Data/Some.hs
+++ b/src/Data/Some.hs
@@ -14,6 +14,8 @@ withSomeM,
 mapSome,
 foldSome,
 traverseSome,
+ThenSome (..),
+BeforeSome (..)
 ) where
 
 #ifdef SOME_NEWTYPE

--- a/src/Data/Some/Church.hs
+++ b/src/Data/Some/Church.hs
@@ -11,6 +11,8 @@ module Data.Some.Church (
     withSomeM,
     foldSome,
     traverseSome,
+    ThenSome (..),
+    BeforeSome (..)
     ) where
 
 import Data.GADT.Internal


### PR DESCRIPTION
* We can support both `*>` (which is the default) and `<*`, so do
  that.

* Clean up some unnecessary `unsafeCoerce` and avoid some unnecessary
  eta expansion.

Closes #29