### PR TITLE
Allow hetrogeneous equality

### DIFF
--- a/src/Data/GADT/Compare.hs
+++ b/src/Data/GADT/Compare.hs
@@ -13,6 +13,7 @@ module Data.GADT.Compare (
     GCompare (..),
     defaultCompare,
     GOrdering (..),
+    GOrdering' (..),
     ) where
 
 import Data.GADT.Internal


### PR DESCRIPTION
I don't think its possible to give a `GRead` instance for `GOrdering`, it only seems possible via a newtype.

Diffs for `dependent-sum` and `dependent-map` are very straighforward.

https://github.com/wz1000/dependent-sum/commit/959aa4f93b9e1aeb816059311df8ef2fd2bf6243

https://github.com/wz1000/dependent-map/commit/

Downside: Can't be supported on anything before GHC 8.2